### PR TITLE
[Merged by Bors] - fix(bors.toml): use maximum timeout suppored by github actions

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 status = ["Build mathlib"]
 use_squash_merge = true
-timeout_sec = 14400
+timeout_sec = 21600


### PR DESCRIPTION
I'm confident we'll be able to breach the four-hour barrier before we move to Lean 4.  Bigger, better, blazingly slow!

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/style.md), [naming](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/naming.md)
  * [ ] reviewed and applied [the documentation requirements](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in the [tactic doc entries](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/doc.md#tactic-doc-entries)
     * [ ] write an example of use of the new feature in [test/tactics.lean](https://github.com/leanprover-community/mathlib/blob/master/test/tactics.lean) or another test file
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/code-review.md)
